### PR TITLE
Linker fix for void specialization of tagIdVal guard

### DIFF
--- a/nova/include/kmac/nova/logger_traits.h
+++ b/nova/include/kmac/nova/logger_traits.h
@@ -79,7 +79,7 @@ struct kmac::nova::logger_traits< void >
 };
 // specialize
 template<>
-constexpr std::uint64_t kmac::nova::details::tagIdVal< kmac::nova::logger_traits< void >::tagId > = kmac::nova::logger_traits< void >::tagId;
+inline constexpr std::uint64_t kmac::nova::details::tagIdVal< kmac::nova::logger_traits< void >::tagId > = kmac::nova::logger_traits< void >::tagId;
 
 //
 // Customization macros


### PR DESCRIPTION
#25: Added inline keyword to tagIdVal< logger_traits< void > > assignment to fix linker issues.