### PR TITLE
Expanding Flare's crash logging and simplifying signal handlers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ include( ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Sanitizers.cmake )
 # build options
 option( NOVA_BUILD_EXTRAS        "Build Nova Extras library"             ON  )
 option( NOVA_BUILD_FLARE         "Build Flare emergency logging library" ON  )
+option( FLARE_SIGNAL_HANDLER     "Build Flare POSIX signal handler (Linux/macOS/Android/FreeBSD)" ON )
 option( NOVA_BUILD_EXAMPLES      "Build example programs"                OFF )
 option( NOVA_BUILD_TESTS         "Build unit tests"                      OFF )
 option( NOVA_BUILD_FUZZ          "Build LibFuzzer fuzz targets"          OFF )
@@ -198,6 +199,15 @@ if( NOVA_BUILD_FLARE )
 	target_link_libraries( nova_flare PUBLIC nova )
 
 	target_compile_features( nova_flare PUBLIC cxx_std_17 )
+
+	# Signal handler support - POSIX only; silently ignored on non-POSIX targets
+	# because signal_handler.cpp guards its entire body behind the same platform check
+	if( FLARE_SIGNAL_HANDLER )
+		target_compile_definitions( nova_flare PUBLIC FLARE_ENABLE_SIGNAL_HANDLER )
+		message( STATUS "Flare: Signal handler enabled (SIGSEGV/SIGBUS/SIGFPE/SIGILL/SIGABRT + std::terminate)" )
+	else()
+		message( STATUS "Flare: Signal handler disabled (set FLARE_SIGNAL_HANDLER=ON to enable)" )
+	endif()
 
 	set_target_properties( nova_flare PROPERTIES
 		EXPORT_NAME Flare

--- a/libs/nova_flare/include/kmac/flare/emergency_sink.h
+++ b/libs/nova_flare/include/kmac/flare/emergency_sink.h
@@ -14,6 +14,9 @@
 namespace kmac::flare
 {
 
+// forward declarations
+struct FaultContext;  // full definition in signal_handler.h
+
 /**
  * @brief Non-templated base for BasicEmergencySink.
  *
@@ -90,12 +93,21 @@ protected:
 	IWriter* writer() const noexcept;
 
 	/**
+	 * @brief Get the load base address captured at construction.
+	 *
+	 * Used by SignalHandler to populate FaultContext::aslrOffset without
+	 * needing to re-query the dynamic linker from a signal handler.
+	 */
+	std::uint64_t loadBaseAddress() const noexcept;
+
+	/**
 	 * @brief Encode a Nova record into a caller-supplied TLV buffer.
 	 *
 	 * @param record the Nova record to encode
 	 * @param buffer destination buffer
 	 * @param bufferSize size of destination buffer in bytes
 	 * @param sequenceNumber monotonic counter for this record
+	 * @param faultContext optional fault context from a signal handler (may be nullptr)
 	 * @return number of bytes written, or 0 on error
 	 *
 	 * @note The caller is responsible for maintaining and incrementing the
@@ -105,7 +117,8 @@ protected:
 		const kmac::nova::Record& record,
 		char* buffer,
 		std::size_t bufferSize,
-		std::size_t sequenceNumber
+		std::size_t sequenceNumber,
+		const FaultContext* faultContext = nullptr
 	) noexcept;
 
 private:
@@ -168,6 +181,9 @@ private:
  *   bare-metal targets with limited interrupt-stack space; increase if
  *   you need longer messages without truncation.
  *
+ *   For bare-metal crash capture considerations (fault vectors, register
+ *   extraction, RamWriter usage) see the TODO in signal_handler.h.
+ *
  *   Minimum useful size is roughly:
  *     8  (magic) + 4 (size) + ~60 (fixed TLVs) + message + stack frames
  *   A static_assert enforces a 256-byte floor.
@@ -176,7 +192,8 @@ private:
  * - MAGIC (8 bytes)
  * - size (4 bytes)
  * - TLVs for status, sequence, timestamp, tag, file, line, function,
- *   process info, load base address, stack frames, message
+ *   process info, fault address (signal records only), load base address,
+ *   ASLR offset, stack frames, register layout + CPU registers, message
  * - END marker
  *
  * Usage (signal handler):
@@ -209,36 +226,92 @@ public:
 	/**
 	 * @brief Encode and write a Nova record.
 	 *
-	 * Allocates a BufferSize-byte buffer on the stack, encodes the record
-	 * into TLV format, and writes it to the underlying IWriter in a single
-	 * call.
-	 *
 	 * @param record the Record to process
 	 */
-	void process( const kmac::nova::Record& record ) noexcept override
-	{
-		if ( writer() == nullptr )
-		{
-			return;
-		}
+	void process( const kmac::nova::Record& record ) noexcept override;
 
-		// fixed-size stack buffer, no heap allocation
-		kmac::nova::platform::Array< char, BufferSize > buffer {};
-		const std::size_t encodedSize = encodeRecordTlv( record, buffer.data(), buffer.size(), _sequenceNumber );
+	/**
+	 * @brief Encode and write a Nova record with fault context from a signal handler.
+	 *
+	 * Called by SignalHandler on crash signal delivery.  Includes fault address,
+	 * ASLR offset, and CPU register snapshot alongside the standard TLVs.
+	 *
+	 * @param record the Record to process
+	 * @param faultContext fault context captured from siginfo_t / ucontext_t
+	 */
+	void processWithFaultContext(
+		const kmac::nova::Record& record,
+		const FaultContext& faultContext
+	) noexcept;
 
-		if ( encodedSize > 0 )
-		{
-			// single atomic write
-			writer()->write( buffer.data(), encodedSize );
-
-			// flush for crash safety
-			writer()->flush();
-
-			// increment sequence number for next record
-			++_sequenceNumber;
-		}
-	}
+private:
+	/**
+	 * @brief Encode and write a record, optionally with fault context.
+	 *
+	 * Common implementation for process() and processWithFaultContext().
+	 * Allocates the stack buffer, encodes, writes, flushes, and advances
+	 * the sequence number.
+	 *
+	 * encodedSize == 0 means the buffer was too small to fit the mandatory
+	 * fixed-size header fields - a silent no-op is the correct response.
+	 * There is nothing meaningful to write, no partial record to flush, and
+	 * in a crash handler there is no way to surface an error.  The sequence
+	 * number is intentionally not incremented: a gap could mislead a reader
+	 * into believing a record was lost in transit, whereas leaving it
+	 * unchanged means the next successful record is numbered as if this
+	 * call never happened.
+	 *
+	 * @param record the Record to encode
+	 * @param faultContext optional fault context (nullptr for normal records)
+	 */
+	void writeRecord( const kmac::nova::Record& record, const FaultContext* faultContext ) noexcept;
 };
+
+template < std::size_t BufferSize >
+void EmergencySink< BufferSize >::process( const kmac::nova::Record& record ) noexcept
+{
+	writeRecord( record, nullptr );
+}
+
+template < std::size_t BufferSize >
+void EmergencySink< BufferSize >::processWithFaultContext(
+	const kmac::nova::Record& record,
+	const FaultContext& faultContext
+) noexcept
+{
+	writeRecord( record, &faultContext );
+}
+
+template < std::size_t BufferSize >
+void EmergencySink< BufferSize >::writeRecord( const kmac::nova::Record& record, const FaultContext* faultContext ) noexcept
+{
+	if ( writer() == nullptr )
+	{
+		return;
+	}
+
+	// fixed-size stack buffer, no heap allocation
+	kmac::nova::platform::Array< char, BufferSize > buffer {};
+	const std::size_t encodedSize = encodeRecordTlv(
+		record,
+		buffer.data(),
+		buffer.size(),
+		_sequenceNumber,
+		faultContext
+	);
+
+	if ( encodedSize > 0 )
+	{
+		// single atomic write
+		writer()->write( buffer.data(), encodedSize );
+
+		// flush for crash safety
+		writer()->flush();
+
+		// increment sequence number for next record
+		++_sequenceNumber;
+	}
+}
 
 } // namespace kmac::flare
 

--- a/libs/nova_flare/include/kmac/flare/emergency_sink.h
+++ b/libs/nova_flare/include/kmac/flare/emergency_sink.h
@@ -18,7 +18,7 @@ namespace kmac::flare
 struct FaultContext;  // full definition in signal_handler.h
 
 /**
- * @brief Non-templated base for BasicEmergencySink.
+ * @brief Non-templated base for EmergencySink.
  *
  * EmergencySinkBase holds all state and implements everything that does not
  * depend on the encoding buffer size: construction, flush(), and the full
@@ -26,7 +26,7 @@ struct FaultContext;  // full definition in signal_handler.h
  * template is process(), which allocates the stack buffer and calls
  * encodeRecordTlv.
  *
- * This class is not intended to be used directly.  Use BasicEmergencySink<N>
+ * This class is not intended to be used directly.  Use EmergencySink<N>
  * or the EmergencySink alias instead.
  *
  * @note EmergencySinkBase must be constructed in a normal (non-signal)
@@ -86,12 +86,6 @@ public:
 	 */
 	void flush() noexcept;
 
-protected:
-	/**
-	 * @brief Get the underlying IWriter.
-	 */
-	IWriter* writer() const noexcept;
-
 	/**
 	 * @brief Get the load base address captured at construction.
 	 *
@@ -99,6 +93,26 @@ protected:
 	 * needing to re-query the dynamic linker from a signal handler.
 	 */
 	std::uint64_t loadBaseAddress() const noexcept;
+
+	/**
+	 * @brief Encode and write a Nova record with fault context from a signal handler.
+	 *
+	 * Called by SignalHandler on crash signal delivery.  Implemented by
+	 * EmergencySink<N> which has the correctly-sized stack buffer.
+	 *
+	 * @param record the Record to process
+	 * @param faultContext fault context captured from siginfo_t / ucontext_t
+	 */
+	virtual void processWithFaultContext(
+		const kmac::nova::Record& record,
+		const FaultContext& faultContext
+	) noexcept = 0;
+
+protected:
+	/**
+	 * @brief Get the underlying IWriter.
+	 */
+	IWriter* writer() const noexcept;
 
 	/**
 	 * @brief Encode a Nova record into a caller-supplied TLV buffer.
@@ -161,7 +175,7 @@ private:
 /**
  * @brief Crash-safe forensic logging sink for Nova.
  *
- * BasicEmergencySink writes Nova log records to a binary stream in TLV format.
+ * EmergencySink writes Nova log records to a binary stream in TLV format.
  * Designed for crash handlers and emergency logging scenarios where:
  * - heap allocation is unsafe
  * - exceptions cannot be used
@@ -212,7 +226,7 @@ private:
  *   static kmac::flare::EmergencySink< 512 > sink( &ramWriter );
  * @endcode
  */
-template < std::size_t BufferSize = 4096 >
+template< std::size_t BufferSize = 4 * 1024 >
 class EmergencySink final : public EmergencySinkBase
 {
 private:
@@ -242,7 +256,7 @@ public:
 	void processWithFaultContext(
 		const kmac::nova::Record& record,
 		const FaultContext& faultContext
-	) noexcept;
+	) noexcept override;
 
 private:
 	/**
@@ -267,13 +281,13 @@ private:
 	void writeRecord( const kmac::nova::Record& record, const FaultContext* faultContext ) noexcept;
 };
 
-template < std::size_t BufferSize >
+template< std::size_t BufferSize >
 void EmergencySink< BufferSize >::process( const kmac::nova::Record& record ) noexcept
 {
 	writeRecord( record, nullptr );
 }
 
-template < std::size_t BufferSize >
+template< std::size_t BufferSize >
 void EmergencySink< BufferSize >::processWithFaultContext(
 	const kmac::nova::Record& record,
 	const FaultContext& faultContext
@@ -282,7 +296,7 @@ void EmergencySink< BufferSize >::processWithFaultContext(
 	writeRecord( record, &faultContext );
 }
 
-template < std::size_t BufferSize >
+template< std::size_t BufferSize >
 void EmergencySink< BufferSize >::writeRecord( const kmac::nova::Record& record, const FaultContext* faultContext ) noexcept
 {
 	if ( writer() == nullptr )

--- a/libs/nova_flare/include/kmac/flare/record.h
+++ b/libs/nova_flare/include/kmac/flare/record.h
@@ -77,6 +77,19 @@ struct Record
 	// will be 0 on unsupported platforms or non-PIE binaries
 	std::uint64_t loadBaseAddress = 0;
 
+	// fault context - only populated when captured via signal handler
+	// (captureRegisters=true on EmergencySinkBase, triggered by signal delivery)
+	std::uint64_t faultAddress = 0;  // si_addr from siginfo_t; 0 if not a fault record
+	std::uint64_t aslrOffset = 0;    // ASLR slide for the main executable
+	bool hasFaultAddress = false;    // false when faultAddress is not meaningful
+
+	// CPU registers at the point of fault, architecture layout identified by registerLayout.
+	// Maximum size covers the largest supported layout (ARM64: 34 x uint64_t = 272 bytes).
+	static constexpr std::size_t MAX_REGISTERS = 34;
+	kmac::nova::platform::Array< std::uint64_t, MAX_REGISTERS > registers { };
+	std::size_t registerCount = 0;   // number of valid entries in registers
+	std::uint8_t registerLayout = 0; // RegisterLayoutId value
+
 	/**
 	 * @brief Reset record to empty state.
 	 */

--- a/libs/nova_flare/include/kmac/flare/signal_handler.h
+++ b/libs/nova_flare/include/kmac/flare/signal_handler.h
@@ -55,10 +55,11 @@ struct FaultContext
  */
 class SignalHandlerBase
 {
-private:
+public:
 	// number of signals we handle
 	static constexpr std::size_t NUM_SIGNALS = 5;
 
+private:
 	// signal numbers we install handlers for
 	static const kmac::nova::platform::Array< int, NUM_SIGNALS > HANDLED_SIGNALS;
 
@@ -68,7 +69,7 @@ private:
 
 	// saved previous signal actions so we can restore + re-raise
 	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-	static kmac::nova::platform::Array< sigaction, NUM_SIGNALS > _previousActions;
+	static kmac::nova::platform::Array< struct sigaction, NUM_SIGNALS > _previousActions;
 
 	// saved previous terminate handler
 	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/libs/nova_flare/include/kmac/flare/signal_handler.h
+++ b/libs/nova_flare/include/kmac/flare/signal_handler.h
@@ -162,9 +162,9 @@ private:
  *   at a time (signals are masked for the duration of handler execution).
  *
  * @tparam StackSize size of the alternate signal stack in bytes.
- *   Must be at least MINSIGSTKSZ.  The default (8192) is sufficient for
- *   the handler body and a few frames of call depth.  Increase if your
- *   signal handler or any function it calls has large stack frames.
+ *   Must be at least 2048.  The default (8192) is sufficient for the handler
+ *   body and a few frames of call depth.  Increase if your signal handler or
+ *   any function it calls has large stack frames.
  *
  * @note Designed for Linux, Android, macOS, and FreeBSD.
  *   Not available on Windows or bare-metal targets.
@@ -241,7 +241,11 @@ template < std::size_t StackSize = 8 * 1024 >
 class SignalHandler : public SignalHandlerBase
 {
 private:
-	static_assert( StackSize >= MINSIGSTKSZ, "StackSize must be at least MINSIGSTKSZ bytes" );
+	// can't use MINSIGSTKSZ directly in a static_assert because glibc 2.34+
+	// made it a runtime sysconf() call, not a constant; 2048 bytes is a safe,
+	// portable floor (larger than the historical MINSIGSTKSZ on all supported
+	// architectures, which is typically 2048 on x86-64, 5120 on ARM64)
+	static_assert( StackSize >= 2048, "StackSize must be at least 2048 bytes" );
 
 	// alternate stack storage (static so it outlives signal delivery)
 	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/libs/nova_flare/include/kmac/flare/signal_handler.h
+++ b/libs/nova_flare/include/kmac/flare/signal_handler.h
@@ -5,7 +5,7 @@
 // SignalHandler is a POSIX-only facility.  Guard the entire header so
 // non-POSIX translation units can include nova_flare headers without error.
 #if defined( __linux__ ) || defined( __APPLE__ ) || defined( __FreeBSD__ ) || defined( __ANDROID__ )
-#define FLARE_HAVE_FAULT_CONTEXT 1
+#define FLARE_HAVE_FAULT_CONTEXT 1 /* NOLINT(cppcoreguidelines-macro-usage) */
 
 #include "emergency_sink.h"
 
@@ -112,7 +112,7 @@ private:
 	 * Captures fault context from siginfo_t and ucontext_t, writes a
 	 * crash record via _sink, then re-raises to restore default behaviour.
 	 */
-	static void signalHandler( int signum, siginfo_t* info, void* ucontext ) noexcept;
+	static void signalHandler( int signum, siginfo_t* info, void* uctx ) noexcept;
 
 	/**
 	 * @brief std::terminate replacement that logs before aborting.

--- a/libs/nova_flare/include/kmac/flare/signal_handler.h
+++ b/libs/nova_flare/include/kmac/flare/signal_handler.h
@@ -68,7 +68,7 @@ private:
 
 	// saved previous signal actions so we can restore + re-raise
 	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-	static kmac::nova::platform::Array< struct sigaction, NUM_SIGNALS > _previousActions;
+	static kmac::nova::platform::Array< sigaction, NUM_SIGNALS > _previousActions;
 
 	// saved previous terminate handler
 	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/libs/nova_flare/include/kmac/flare/signal_handler.h
+++ b/libs/nova_flare/include/kmac/flare/signal_handler.h
@@ -1,0 +1,271 @@
+#pragma once
+#ifndef KMAC_FLARE_SIGNAL_HANDLER_H
+#define KMAC_FLARE_SIGNAL_HANDLER_H
+
+// SignalHandler is a POSIX-only facility.  Guard the entire header so
+// non-POSIX translation units can include nova_flare headers without error.
+#if defined( __linux__ ) || defined( __APPLE__ ) || defined( __FreeBSD__ ) || defined( __ANDROID__ )
+#define FLARE_HAVE_FAULT_CONTEXT 1
+
+#include "emergency_sink.h"
+
+#include <kmac/nova/record.h>
+#include <kmac/nova/platform/array.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <signal.h>
+
+namespace kmac::flare
+{
+
+/**
+ * @brief Fault context captured from a signal handler.
+ *
+ * Passed to EmergencySinkBase::processWithFaultContext() to write crash
+ * records that include the faulting address, ASLR offset, and CPU registers.
+ * All fields are async-signal-safe to populate from within a signal handler.
+ */
+struct FaultContext
+{
+	std::uint64_t faultAddress = 0;    // si_addr cast to uint64_t; 0 if unavailable
+	bool hasFaultAddress = false;      // true when faultAddress is meaningful
+
+	std::uint64_t aslrOffset = 0;      // ASLR slide for the main executable
+
+	// CPU registers at the point of fault.
+	// Layout is architecture-specific; see RegisterLayoutId in tlv.h.
+	// Maximum size covers the largest supported layout (ARM64: 34 registers).
+	static constexpr std::size_t MAX_REGISTERS = 34;
+	kmac::nova::platform::Array< std::uint64_t, MAX_REGISTERS > registers {};
+	std::size_t registerCount = 0;
+	std::uint8_t layoutId = 0;         // RegisterLayoutId value
+};
+
+/**
+ * @brief Non-templated base for SignalHandler.
+ *
+ * SignalHandlerBase holds all state and implements everything that does not
+ * depend on the alternate stack size: signal handler installation, fault
+ * context capture, and crash record writing.  The only thing left to the
+ * derived template is the alternate stack buffer and the public install()
+ * entry point that passes it to SignalHandlerBase::install().
+ *
+ * This class is not intended to be used directly.  Use SignalHandler<N>.
+ */
+class SignalHandlerBase
+{
+private:
+	// number of signals we handle
+	static constexpr std::size_t NUM_SIGNALS = 5;
+
+	// signal numbers we install handlers for
+	static const kmac::nova::platform::Array< int, NUM_SIGNALS > HANDLED_SIGNALS;
+
+	// the sink that crash records are routed to
+	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+	static EmergencySinkBase* _sink;
+
+	// saved previous signal actions so we can restore + re-raise
+	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+	static kmac::nova::platform::Array< struct sigaction, NUM_SIGNALS > _previousActions;
+
+	// saved previous terminate handler
+	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+	static void ( *_previousTerminateHandler )();
+
+public:
+	/**
+	 * @brief Uninstall crash signal handlers, restoring previous handlers.
+	 *
+	 * Restores the signal dispositions saved at install() time and
+	 * removes the std::set_terminate handler.  Frees the alternate stack.
+	 *
+	 * @note Safe to call even if install() was never called (no-op).
+	 */
+	static void uninstall() noexcept;
+
+protected:
+	/**
+	 * @brief Install crash signal handlers using the given sink.
+	 *
+	 * Configures an alternate signal stack and installs handlers for
+	 * SIGSEGV, SIGBUS, SIGFPE, SIGILL, and SIGABRT.  Also installs a
+	 * std::set_terminate handler.
+	 *
+	 * Previous signal dispositions are saved and restored on re-raise.
+	 *
+	 * @param altStackBuffer buffer for alt stack
+	 * @param altStackSize size of alt stack buffer
+	 * @param sink sink to receive crash records (must outlive the process)
+	 *
+	 * @note Must be called from a normal (non-signal) context.
+	 * @note Calling install() more than once replaces the registered sink.
+	 */
+	static void install( char* altStackBuffer, std::size_t altStackSize, EmergencySinkBase* sink ) noexcept;
+
+private:
+	/**
+	 * @brief SA_SIGINFO-compatible signal handler.
+	 *
+	 * Captures fault context from siginfo_t and ucontext_t, writes a
+	 * crash record via _sink, then re-raises to restore default behaviour.
+	 */
+	static void signalHandler( int signum, siginfo_t* info, void* ucontext ) noexcept;
+
+	/**
+	 * @brief std::terminate replacement that logs before aborting.
+	 */
+	static void terminateHandler() noexcept;
+
+	/**
+	 * @brief Populate FaultContext from siginfo_t and ucontext_t.
+	 *
+	 * Architecture-specific register extraction happens here.
+	 * The ASLR offset stored in _sink is copied into ctx.aslrOffset.
+	 *
+	 * @param info siginfo_t pointer from the signal handler (may be null)
+	 * @param uctx ucontext_t pointer from the signal handler (may be null)
+	 * @param ctx output FaultContext
+	 */
+	static void buildFaultContext( const siginfo_t* info, const void* uctx, FaultContext& ctx ) noexcept;
+};
+
+/**
+ * @brief Install Flare signal handlers for crash-capturing signals.
+ *
+ * SignalHandler configures the alternate signal stack (sigaltstack) and
+ * installs signal handlers via sigaction with SA_ONSTACK | SA_SIGINFO for
+ * SIGSEGV, SIGBUS, SIGFPE, SIGILL, and SIGABRT.  It also installs a
+ * std::set_terminate handler for C++ exception faults.
+ *
+ * On signal delivery the handler:
+ *   1. assembles a FaultContext from siginfo_t (fault address) and
+ *      ucontext_t (CPU registers)
+ *   2. writes a crash record via the bound EmergencySinkBase so the fault
+ *      context is included in the TLV output
+ *   3. restores the previous (default) signal handler and re-raises to
+ *      produce a core dump and correct exit status
+ *
+ * Usage:
+ * @code
+ *   // construct sink and writer at startup, before install()
+ *   static kmac::flare::FdWriter writer( fd );
+ *   static kmac::flare::EmergencySink<> sink( &writer, true, true );
+ *
+ *   kmac::flare::SignalHandler<>::install( &sink );
+ * @endcode
+ *
+ * Thread safety:
+ *   install() and uninstall() must be called from a single thread.
+ *   The signal handler itself is re-entrant-safe for a single signal
+ *   at a time (signals are masked for the duration of handler execution).
+ *
+ * @tparam StackSize size of the alternate signal stack in bytes.
+ *   Must be at least MINSIGSTKSZ.  The default (8192) is sufficient for
+ *   the handler body and a few frames of call depth.  Increase if your
+ *   signal handler or any function it calls has large stack frames.
+ *
+ * @note Designed for Linux, Android, macOS, and FreeBSD.
+ *   Not available on Windows or bare-metal targets.
+ *
+ * @note The alternate signal stack is mandatory for SIGSEGV caused by stack
+ *   overflow: the faulting stack cannot be used to run the handler.
+ *
+ * @note SIGABRT may arrive without a meaningful si_addr (e.g. from abort()).
+ *   hasFaultAddress will be false in the FaultContext for those records.
+ *
+ * @note Bare-metal crash capture (deferred - requires separate planning):
+ *   On bare-metal targets there are no POSIX signals, no sigaltstack, and no
+ *   /proc filesystem, so SignalHandler cannot be ported directly.  Crash
+ *   capture requires platform-specific fault handler hooks instead:
+ *
+ *   Fault entry points:
+ *   - ARM Cortex-M: HardFault_Handler, MemManage_Handler, BusFault_Handler,
+ *     UsageFault_Handler in the vector table.  The processor pushes a
+ *     standard exception frame (r0-r3, r12, LR, PC, xPSR) onto the stack
+ *     automatically before branching to the handler, so register capture
+ *     does not require inline assembly beyond reading the pre-fault SP.
+ *   - ARM Cortex-A / Cortex-R: undefined instruction, data abort, prefetch
+ *     abort, and FIQ/IRQ vectors.  The banked registers and SPSR must be
+ *     saved manually in the vector stubs before branching to C handlers.
+ *   - RISC-V: trap handler pointed to by mtvec/stvec; mcause/scause
+ *     identifies the fault type; mtval/stval holds the fault address.
+ *
+ *   Stack overflow detection:
+ *   - Cortex-M MPU: configure a no-access region at the bottom of each
+ *     task stack; a MemManage fault fires before the stack corrupts the
+ *     heap.  The handler must run from a separate stack (MSP vs PSP on
+ *     Cortex-M, or a dedicated IRQ stack on A/R profiles).
+ *   - FreeRTOS: configCHECK_FOR_STACK_OVERFLOW hook provides a software
+ *     check at each context switch, but does not replace MPU protection.
+ *
+ *   Fault address:
+ *   - Cortex-M: MMFAR (MemManage Fault Address Register) and BFAR (Bus
+ *     Fault Address Register) in the SCB hold the faulting address when
+ *     the corresponding VALID bit is set in MMFSR/BFSR.
+ *   - Cortex-A: the abort-mode LR and the CP15 DFAR/IFAR registers.
+ *   - RISC-V: mtval/stval directly holds the fault address.
+ *
+ *   Load base / ASLR:
+ *   - Bare-metal binaries are typically non-PIE and loaded at a fixed
+ *     address from the linker script.  The ASLR offset is always 0, so
+ *     stack frame addresses are already static and can be passed directly
+ *     to addr2line without relocation.
+ *
+ *   Register capture:
+ *   - Cortex-M: read the exception frame from the stacked SP to recover
+ *     r0-r3, r12, LR, PC, xPSR.  Callee-saved registers (r4-r11) are not
+ *     stacked automatically and must be saved in the handler prologue
+ *     before any C code runs (i.e. in the vector stub assembly).
+ *   - Cortex-A/R and RISC-V: all registers must be saved in the trap
+ *     entry stub; no automatic hardware stacking.
+ *
+ *   Writer:
+ *   - FdWriter is unavailable (no file descriptors).  Use RamWriter to
+ *     write into a dedicated crash buffer, or UartWriter to stream directly
+ *     over a serial port.  The crash buffer should be placed in a
+ *     non-initialised RAM section so its contents survive a warm reset and
+ *     can be read by the bootloader or a subsequent run of the application.
+ *
+ *   Suggested implementation approach:
+ *   - Provide a BareMetalFaultHandler class (analogous to SignalHandler)
+ *     that installs itself into the relevant fault vectors at construction
+ *     and provides a static fault entry point suitable for use as a
+ *     C-linkage vector table entry.
+ *   - FaultContext population can reuse the same struct and TLV encoding
+ *     path as the hosted implementation; only the fault entry and register
+ *     extraction are platform-specific.
+ */
+template < std::size_t StackSize = 8 * 1024 >
+class SignalHandler : public SignalHandlerBase
+{
+private:
+	static_assert( StackSize >= MINSIGSTKSZ, "StackSize must be at least MINSIGSTKSZ bytes" );
+
+	// alternate stack storage (static so it outlives signal delivery)
+	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+	static kmac::nova::platform::Array< char, StackSize > _altStack;
+
+public:
+	static void install( EmergencySinkBase* sink ) noexcept;
+};
+
+// static member definitions
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+template< std::size_t StackSize >
+kmac::nova::platform::Array< char, StackSize > SignalHandler< StackSize >::_altStack {};
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+template < std::size_t StackSize >
+void SignalHandler< StackSize >::install( EmergencySinkBase* sink ) noexcept
+{
+	install( _altStack.data(), _altStack.size(), sink );
+}
+
+} // namespace kmac::flare
+
+#endif // POSIX platforms
+
+#endif // KMAC_FLARE_SIGNAL_HANDLER_H

--- a/libs/nova_flare/include/kmac/flare/tlv.h
+++ b/libs/nova_flare/include/kmac/flare/tlv.h
@@ -32,19 +32,76 @@ enum class TlvType : uint16_t
 	MessageTruncated    = 21,  // indicates message was truncated due to buffer limits
 
 	// crash context (30-39 reserved for crash diagnostics)
+	//
+	// TLV ordering within a crash record follows the dependency chain a
+	// reader needs to interpret addresses:
+	//   FaultAddress    - what faulted (si_addr; present only in signal records)
+	//   LoadBaseAddress - where the binary is loaded at runtime
+	//   AslrOffset      - ASLR slide (equals LoadBaseAddress for PIE; stored
+	//                     explicitly so readers need no binary at read time)
+	//   StackFrames     - runtime return addresses (subtract AslrOffset for
+	//                     static/file-relative addresses for addr2line)
+	//   RegisterLayout  - identifies the register array layout that follows
+	//   CpuRegisters    - register snapshot at the point of fault
+
+	// FaultAddress: memory address that triggered the fault (uint64_t).
+	// Sourced from siginfo_t::si_addr.  Present only when a signal handler
+	// captures the siginfo_t context (e.g. SIGSEGV, SIGBUS, SIGFPE, SIGILL).
+	// Absent for SIGABRT records where si_addr is not meaningful.
+	FaultAddress        = 30,
+
 	// LoadBaseAddress: runtime load base of the main executable (uint64_t).
 	// Required to convert stack frame addresses to static addresses for
 	// symbolization when the binary is position-independent (PIE/ASLR).
 	// Captured once at EmergencySink construction, not per-record.
 	// static_addr = frame_addr - load_base_address
-	LoadBaseAddress     = 30,
+	LoadBaseAddress     = 31,
+
+	// AslrOffset: the Address Space Layout Randomization (ASLR) slide applied
+	// to the main executable (uint64_t).  For Position Independent Executable
+	// (PIE) binaries on Linux/Android/macOS this equals LoadBaseAddress.
+	// Stored explicitly so flare_reader.py can relocate addresses without
+	// needing the binary present at read time.
+	AslrOffset          = 32,
 
 	// StackFrames: tightly-packed array of uint64_t return addresses,
 	// little-endian, innermost frame first, frame count = tlv_length / 8.
-	StackFrames         = 31,
+	StackFrames         = 33,
+
+	// RegisterLayout: identifies the architecture and register ordering for
+	// the CpuRegisters TLV that follows (uint8_t).  See RegisterLayoutId enum.
+	// Written immediately before CpuRegisters so readers can decode the array
+	// without inspecting the binary or knowing the target architecture.
+	RegisterLayout      = 34,
+
+	// CpuRegisters: tightly-packed array of uint64_t register values,
+	// little-endian, register count = tlv_length / 8.
+	// Architecture-specific field order is documented in RegisterLayoutId.
+	// Supported layouts:
+	//   x86-64: rax, rbx, rcx, rdx, rsi, rdi, rbp, rsp, r8-r15, rip, rflags
+	//           (18 registers, 144 bytes)
+	//   ARM64:  x0-x30, sp, pc, pstate
+	//           (34 registers, 272 bytes)
+	//   ARM32:  r0-r15, cpsr
+	//           (17 registers, 136 bytes)
+	CpuRegisters        = 35,
 
 	// record terminator
 	RecordEnd           = 0xFFFF
+};
+
+/**
+ * @brief Identifies the architecture-specific register layout in a CpuRegisters TLV.
+ *
+ * Written as the value of a RegisterLayout TLV immediately preceding the
+ * CpuRegisters TLV so readers can decode registers without inspecting the binary.
+ */
+enum class RegisterLayoutId : uint8_t
+{
+	Unknown = 0,
+	X86_64  = 1,  ///< see TlvType::CpuRegisters for field order
+	Arm64   = 2,  ///< see TlvType::CpuRegisters for field order
+	Arm32   = 3,  ///< see TlvType::CpuRegisters for field order
 };
 
 /**

--- a/libs/nova_flare/src/kmac/flare/emergency_sink.cpp
+++ b/libs/nova_flare/src/kmac/flare/emergency_sink.cpp
@@ -1,6 +1,7 @@
 #include "kmac/flare/emergency_sink.h"
 
 #include "kmac/flare/record.h"
+#include "kmac/flare/signal_handler.h"
 #include "kmac/flare/tlv.h"
 
 #include <kmac/nova/details.h>
@@ -10,7 +11,7 @@
 #include <cstring>
 #include <stdint.h>
 
-// Platform-specific includes for process/thread IDs
+// platform-specific includes for process/thread IDs
 #if defined( __linux__ ) || defined( __unix__ ) || defined( __APPLE__ ) || defined( __FreeBSD__ )
 #include <unistd.h>  // getpid()
 #endif
@@ -98,9 +99,18 @@ struct TlvWriteHelper
 
 	void writeLoadBaseAddressTlv( std::uint64_t loadBaseAddress ) noexcept;
 
+	void writeAslrOffsetTlv( std::uint64_t aslrOffset ) noexcept;
+
 	// frames: array of raw return addresses
 	// frameCount: number of valid entries
 	void writeStackFramesTlv( void* const* frames, std::size_t frameCount ) noexcept;
+
+	// registers: packed uint64_t values; layoutId identifies the architecture
+	void writeCpuRegistersTlv(
+		const std::uint64_t* registers,
+		std::size_t registerCount,
+		kmac::flare::RegisterLayoutId layoutId
+	) noexcept;
 
 	// returns true if message was truncated
 	bool writeMessageTlv( const kmac::nova::Record& record ) noexcept;
@@ -132,9 +142,24 @@ IWriter* EmergencySinkBase::writer() const noexcept
 	return _writer;
 }
 
-std::size_t EmergencySinkBase::encodeRecordTlv( const kmac::nova::Record& record, char* buffer, std::size_t bufferSize, std::size_t sequenceNumber ) noexcept
+std::uint64_t EmergencySinkBase::loadBaseAddress() const noexcept
+{
+	return _loadBaseAddress;
+}
+
+std::size_t EmergencySinkBase::encodeRecordTlv(
+	const kmac::nova::Record& record,
+	char* buffer,
+	std::size_t bufferSize,
+	std::size_t sequenceNumber,
+	const FaultContext* faultContext
+) noexcept
 {
 	std::size_t offset = 0;
+
+#if ! defined( FLARE_HAVE_FAULT_CONTEXT )
+	(void) faultContext;
+#endif
 	::TlvWriteHelper writeHelper{ buffer, offset, bufferSize };
 
 	// write magic number
@@ -199,10 +224,37 @@ std::size_t EmergencySinkBase::encodeRecordTlv( const kmac::nova::Record& record
 		writeHelper.writeProcessInfoTlv();
 	}
 
-	// write load base address (always; value is 0 on unsupported platforms)
+	// crash context TLVs - written in dependency order so readers can interpret
+	// each field using only what came before it in the stream:
+	//   fault address  - what faulted (si_addr; only present for signal records)
+	//   load base      - where the binary landed at runtime
+	//   ASLR offset    - slide to subtract from runtime addresses for symbolisation
+	//   stack frames   - runtime return addresses (subtract AslrOffset in reader to get static addresses)
+	//   register layout + registers - CPU state at fault point
+
+#if defined( FLARE_HAVE_FAULT_CONTEXT )
+	if ( faultContext != nullptr && faultContext->hasFaultAddress )
+	{
+		writeHelper.writeTlv(
+			TlvType::FaultAddress,
+			&faultContext->faultAddress,
+			sizeof( faultContext->faultAddress )
+		);
+	}
+#endif
+
+	// load base address (always written; 0 on unsupported platforms)
 	writeHelper.writeLoadBaseAddressTlv( _loadBaseAddress );
 
-	// write stack trace if enabled and compile-time support is present
+	// ASLR offset (written when fault context is present; equals load base for PIE)
+#if defined( FLARE_HAVE_FAULT_CONTEXT )
+	if ( faultContext != nullptr )
+	{
+		writeHelper.writeAslrOffsetTlv( faultContext->aslrOffset );
+	}
+#endif
+
+	// stack trace - from fault context registers if available, otherwise backtrace()
 	if ( _captureStackTrace )
 	{
 		kmac::nova::platform::Array< void*, Record::MAX_STACK_FRAMES > frames {};
@@ -212,6 +264,18 @@ std::size_t EmergencySinkBase::encodeRecordTlv( const kmac::nova::Record& record
 			writeHelper.writeStackFramesTlv( std::data( frames ), frameCount );
 		}
 	}
+
+	// CPU registers (register layout TLV precedes the register array)
+#if defined( FLARE_HAVE_FAULT_CONTEXT )
+	if ( faultContext != nullptr && faultContext->registerCount > 0 )
+	{
+		writeHelper.writeCpuRegistersTlv(
+			faultContext->registers.data(),
+			faultContext->registerCount,
+			static_cast< kmac::flare::RegisterLayoutId >( faultContext->layoutId )
+		);
+	}
+#endif
 
 	// write message, with truncation fallback
 	const bool messageTruncated = writeHelper.writeMessageTlv( record );
@@ -490,6 +554,40 @@ void TlvWriteHelper::writeProcessInfoTlv() noexcept
 void TlvWriteHelper::writeLoadBaseAddressTlv( std::uint64_t loadBaseAddress ) noexcept
 {
 	writeTlv( kmac::flare::TlvType::LoadBaseAddress, &loadBaseAddress, sizeof( loadBaseAddress ) );
+}
+
+void TlvWriteHelper::writeAslrOffsetTlv( std::uint64_t aslrOffset ) noexcept
+{
+	writeTlv( kmac::flare::TlvType::AslrOffset, &aslrOffset, sizeof( aslrOffset ) );
+}
+
+void TlvWriteHelper::writeCpuRegistersTlv(
+	const std::uint64_t* registers,
+	std::size_t registerCount,
+	kmac::flare::RegisterLayoutId layoutId
+) noexcept
+{
+	if ( registers == nullptr || registerCount == 0 )
+	{
+		return;
+	}
+
+	static_assert(
+		kmac::flare::Record::MAX_REGISTERS * sizeof( std::uint64_t ) <= UINT16_MAX,
+		"MAX_REGISTERS too large for uint16_t TLV length field"
+	);
+
+	const std::size_t count = registerCount < kmac::flare::Record::MAX_REGISTERS
+		? registerCount
+		: kmac::flare::Record::MAX_REGISTERS;
+
+	// RegisterLayout TLV precedes CpuRegisters so readers can decode the array
+	// without knowing the target architecture out-of-band
+	const std::uint8_t layoutByte = std::uint8_t( layoutId );
+	writeTlv( kmac::flare::TlvType::RegisterLayout, &layoutByte, sizeof( layoutByte ) );
+
+	const std::uint16_t payloadLen = static_cast< std::uint16_t >( count * sizeof( std::uint64_t ) );
+	writeTlv( kmac::flare::TlvType::CpuRegisters, registers, payloadLen );
 }
 
 void TlvWriteHelper::writeStackFramesTlv( void* const* frames, std::size_t frameCount ) noexcept

--- a/libs/nova_flare/src/kmac/flare/emergency_sink.cpp
+++ b/libs/nova_flare/src/kmac/flare/emergency_sink.cpp
@@ -101,6 +101,10 @@ struct TlvWriteHelper
 
 	void writeAslrOffsetTlv( std::uint64_t aslrOffset ) noexcept;
 
+	// writes FaultAddress (if present), AslrOffset, and CpuRegisters TLVs from fault context;
+	// no-op when faultContext is null (non-POSIX builds or normal log records)
+	void writeFaultContextTlvs( const kmac::flare::FaultContext* faultContext ) noexcept;
+
 	// frames: array of raw return addresses
 	// frameCount: number of valid entries
 	void writeStackFramesTlv( void* const* frames, std::size_t frameCount ) noexcept;
@@ -231,30 +235,12 @@ std::size_t EmergencySinkBase::encodeRecordTlv(
 	//   ASLR offset    - slide to subtract from runtime addresses for symbolisation
 	//   stack frames   - runtime return addresses (subtract AslrOffset in reader to get static addresses)
 	//   register layout + registers - CPU state at fault point
-
-#if defined( FLARE_HAVE_FAULT_CONTEXT )
-	if ( faultContext != nullptr && faultContext->hasFaultAddress )
-	{
-		writeHelper.writeTlv(
-			TlvType::FaultAddress,
-			&faultContext->faultAddress,
-			sizeof( faultContext->faultAddress )
-		);
-	}
-#endif
+	writeHelper.writeFaultContextTlvs( faultContext );
 
 	// load base address (always written; 0 on unsupported platforms)
 	writeHelper.writeLoadBaseAddressTlv( _loadBaseAddress );
 
-	// ASLR offset (written when fault context is present; equals load base for PIE)
-#if defined( FLARE_HAVE_FAULT_CONTEXT )
-	if ( faultContext != nullptr )
-	{
-		writeHelper.writeAslrOffsetTlv( faultContext->aslrOffset );
-	}
-#endif
-
-	// stack trace - from fault context registers if available, otherwise backtrace()
+	// stack trace
 	if ( _captureStackTrace )
 	{
 		kmac::nova::platform::Array< void*, Record::MAX_STACK_FRAMES > frames {};
@@ -264,18 +250,6 @@ std::size_t EmergencySinkBase::encodeRecordTlv(
 			writeHelper.writeStackFramesTlv( std::data( frames ), frameCount );
 		}
 	}
-
-	// CPU registers (register layout TLV precedes the register array)
-#if defined( FLARE_HAVE_FAULT_CONTEXT )
-	if ( faultContext != nullptr && faultContext->registerCount > 0 )
-	{
-		writeHelper.writeCpuRegistersTlv(
-			faultContext->registers.data(),
-			faultContext->registerCount,
-			static_cast< kmac::flare::RegisterLayoutId >( faultContext->layoutId )
-		);
-	}
-#endif
 
 	// write message, with truncation fallback
 	const bool messageTruncated = writeHelper.writeMessageTlv( record );
@@ -559,6 +533,38 @@ void TlvWriteHelper::writeLoadBaseAddressTlv( std::uint64_t loadBaseAddress ) no
 void TlvWriteHelper::writeAslrOffsetTlv( std::uint64_t aslrOffset ) noexcept
 {
 	writeTlv( kmac::flare::TlvType::AslrOffset, &aslrOffset, sizeof( aslrOffset ) );
+}
+
+void TlvWriteHelper::writeFaultContextTlvs( const kmac::flare::FaultContext* faultContext ) noexcept
+{
+#if defined( FLARE_HAVE_FAULT_CONTEXT )
+	if ( faultContext == nullptr )
+	{
+		return;
+	}
+
+	if ( faultContext->hasFaultAddress )
+	{
+		writeTlv(
+			kmac::flare::TlvType::FaultAddress,
+			&faultContext->faultAddress,
+			sizeof( faultContext->faultAddress )
+		);
+	}
+
+	writeAslrOffsetTlv( faultContext->aslrOffset );
+
+	if ( faultContext->registerCount > 0 )
+	{
+		writeCpuRegistersTlv(
+			faultContext->registers.data(),
+			faultContext->registerCount,
+			static_cast< kmac::flare::RegisterLayoutId >( faultContext->layoutId )
+		);
+	}
+#else
+	(void) faultContext;
+#endif
 }
 
 void TlvWriteHelper::writeCpuRegistersTlv(

--- a/libs/nova_flare/src/kmac/flare/emergency_sink.cpp
+++ b/libs/nova_flare/src/kmac/flare/emergency_sink.cpp
@@ -118,6 +118,18 @@ struct TlvWriteHelper
 
 	// returns true if message was truncated
 	bool writeMessageTlv( const kmac::nova::Record& record ) noexcept;
+
+	// write the FLARE_MAGIC and size-field placeholder; returns the offset of the
+	// size field so it can be back-patched, or SIZE_MAX on failure
+	std::size_t writeRecordHeader() noexcept;
+
+	// back-patch the size field and update the status byte; called after all TLVs
+	// are written but before the end marker so the final size includes everything
+	void finaliseRecord(
+		std::size_t sizeFieldOffset,
+		std::size_t statusByteOffset,
+		bool messageTruncated
+	) noexcept;
 };
 
 } // anonymous namespace
@@ -166,21 +178,12 @@ std::size_t EmergencySinkBase::encodeRecordTlv(
 #endif
 	::TlvWriteHelper writeHelper{ buffer, offset, bufferSize };
 
-	// write magic number
-	if ( offset + sizeof( FLARE_MAGIC ) > bufferSize )
+	// write magic and reserve size field; returns offset of size field or SIZE_MAX on failure
+	const std::size_t sizeFieldOffset = writeHelper.writeRecordHeader();
+	if ( sizeFieldOffset == SIZE_MAX )
 	{
 		return 0;
 	}
-	std::memcpy( buffer + offset, &FLARE_MAGIC, sizeof( FLARE_MAGIC ) );
-	offset += sizeof( FLARE_MAGIC );
-
-	// reserve space for total size (filled in at the end)
-	const std::size_t sizeOffset = offset;
-	if ( ( offset + sizeof( std::uint32_t ) ) > bufferSize )
-	{
-		return 0;
-	}
-	offset += sizeof( std::uint32_t );
 
 	// write the status as InProgress initially
 	// (if we crash before updating it, reader knows it's a torn write)
@@ -189,55 +192,39 @@ std::size_t EmergencySinkBase::encodeRecordTlv(
 	{
 		return 0;
 	}
-	const std::size_t statusOffset = offset - sizeof( status );  // remember where status is
+	const std::size_t statusOffset = offset - sizeof( status );
 
-	// write mandatory fields, starting with the sequence number
+	// mandatory fields
 	if ( ! writeHelper.writeTlv( TlvType::SequenceNumber, &sequenceNumber, sizeof( sequenceNumber ) ) )
 	{
 		return 0;
 	}
-
-	// write the timestamp
 	if ( ! writeHelper.writeTlv( TlvType::TimestampNs, &record.timestamp, sizeof( record.timestamp ) ) )
 	{
 		return 0;
 	}
-
-	// write the tag as hash (for compact storage)
 	std::uint64_t tagHash = hashString( record.tag );
 	if ( ! writeHelper.writeTlv( TlvType::TagId, &tagHash, sizeof( tagHash ) ) )
 	{
 		return 0;
 	}
 
-	// write optional source location fields, starting with the file name (if not too long)
+	// source location
 	writeHelper.writeStringTlv( TlvType::FileName, record.file );
-
-	// write the line number
 	if ( ! writeHelper.writeTlv( TlvType::LineNumber, &record.line, sizeof( record.line ) ) )
 	{
 		return 0;
 	}
-
-	// write the function name (if not too long)
 	writeHelper.writeStringTlv( TlvType::FunctionName, record.function );
 
-	// write the process/thread info if enabled
+	// process/thread info
 	if ( _captureProcessInfo )
 	{
 		writeHelper.writeProcessInfoTlv();
 	}
 
-	// crash context TLVs - written in dependency order so readers can interpret
-	// each field using only what came before it in the stream:
-	//   fault address  - what faulted (si_addr; only present for signal records)
-	//   load base      - where the binary landed at runtime
-	//   ASLR offset    - slide to subtract from runtime addresses for symbolisation
-	//   stack frames   - runtime return addresses (subtract AslrOffset in reader to get static addresses)
-	//   register layout + registers - CPU state at fault point
+	// crash context TLVs (fault address, ASLR offset, registers) then load base
 	writeHelper.writeFaultContextTlvs( faultContext );
-
-	// load base address (always written; 0 on unsupported platforms)
 	writeHelper.writeLoadBaseAddressTlv( _loadBaseAddress );
 
 	// stack trace
@@ -251,38 +238,28 @@ std::size_t EmergencySinkBase::encodeRecordTlv(
 		}
 	}
 
-	// write message, with truncation fallback
+	// message
 	const bool messageTruncated = writeHelper.writeMessageTlv( record );
-
-	// if message was truncated, add truncation marker
 	if ( messageTruncated )
 	{
 		const std::uint8_t truncFlag = 1;
 		writeHelper.writeTlv( TlvType::MessageTruncated, &truncFlag, sizeof( truncFlag ) );
 	}
 
-	// write end marker
+	// end marker
 	const std::uint16_t endType = std::uint16_t( TlvType::RecordEnd );
 	const std::uint16_t zero = 0;
 	if ( ( offset + sizeof( endType ) + sizeof( zero ) ) > bufferSize )
 	{
 		return 0;
 	}
-
 	std::memcpy( buffer + offset, &endType, sizeof( endType ) );
 	offset += sizeof( endType );
 	std::memcpy( buffer + offset, &zero, sizeof( zero ) );
 	offset += sizeof( zero );
 
-	// update the status to Complete (we made it to the end!)
-	status = messageTruncated
-		? std::uint8_t( RecordStatus::Truncated )
-		: std::uint8_t( RecordStatus::Complete );
-	std::memcpy( buffer + statusOffset, &status, sizeof( status ) );
-
-	// write the total size
-	const std::uint32_t totalSize = std::uint32_t( offset );
-	std::memcpy( buffer + sizeOffset, &totalSize, sizeof( totalSize ) );
+	// back-patch status and total size
+	writeHelper.finaliseRecord( sizeFieldOffset, statusOffset, messageTruncated );
 
 	return offset;
 }
@@ -533,6 +510,44 @@ void TlvWriteHelper::writeLoadBaseAddressTlv( std::uint64_t loadBaseAddress ) no
 void TlvWriteHelper::writeAslrOffsetTlv( std::uint64_t aslrOffset ) noexcept
 {
 	writeTlv( kmac::flare::TlvType::AslrOffset, &aslrOffset, sizeof( aslrOffset ) );
+}
+
+std::size_t TlvWriteHelper::writeRecordHeader() noexcept
+{
+	// write magic number
+	if ( offset + sizeof( kmac::flare::FLARE_MAGIC ) > bufferSize )
+	{
+		return SIZE_MAX;
+	}
+	std::memcpy( buffer + offset, &kmac::flare::FLARE_MAGIC, sizeof( kmac::flare::FLARE_MAGIC ) );
+	offset += sizeof( kmac::flare::FLARE_MAGIC );
+
+	// reserve space for total size field (back-patched by finaliseRecord)
+	const std::size_t sizeFieldOffset = offset;
+	if ( ( offset + sizeof( std::uint32_t ) ) > bufferSize )
+	{
+		return SIZE_MAX;
+	}
+	offset += sizeof( std::uint32_t );
+
+	return sizeFieldOffset;
+}
+
+void TlvWriteHelper::finaliseRecord(
+	std::size_t sizeFieldOffset,
+	std::size_t statusByteOffset,
+	bool messageTruncated
+) noexcept
+{
+	// back-patch status byte
+	const std::uint8_t status = messageTruncated
+		? std::uint8_t( kmac::flare::RecordStatus::Truncated )
+		: std::uint8_t( kmac::flare::RecordStatus::Complete );
+	std::memcpy( buffer + statusByteOffset, &status, sizeof( status ) );
+
+	// back-patch total size
+	const std::uint32_t totalSize = std::uint32_t( offset );
+	std::memcpy( buffer + sizeFieldOffset, &totalSize, sizeof( totalSize ) );
 }
 
 void TlvWriteHelper::writeFaultContextTlvs( const kmac::flare::FaultContext* faultContext ) noexcept

--- a/libs/nova_flare/src/kmac/flare/reader.cpp
+++ b/libs/nova_flare/src/kmac/flare/reader.cpp
@@ -18,6 +18,8 @@ struct TlvFieldParseHelper
 	void parseStringField( kmac::flare::TlvType type, const std::uint8_t* value, std::uint16_t length ) noexcept;
 
 	void parseStackFramesField( const std::uint8_t* value, std::uint16_t length ) noexcept;
+
+	void parseCpuRegistersField( const std::uint8_t* value, std::uint16_t length ) noexcept;
 };
 
 } // namespace
@@ -89,6 +91,10 @@ bool Reader::parseRecord( const std::uint8_t* data, std::size_t size, Record& ou
 		else if ( tlvType == TlvType::StackFrames )
 		{
 			helper.parseStackFramesField( value, length );
+		}
+		else if ( tlvType == TlvType::CpuRegisters )
+		{
+			helper.parseCpuRegistersField( value, length );
 		}
 		else
 		{
@@ -176,6 +182,28 @@ void TlvFieldParseHelper::parseFixedField( kmac::flare::TlvType type, const std:
 		}
 		break;
 
+	case kmac::flare::TlvType::FaultAddress:
+		if ( length == sizeof( std::uint64_t ) )
+		{
+			std::memcpy( &record.faultAddress, value, sizeof( std::uint64_t ) );
+			record.hasFaultAddress = true;
+		}
+		break;
+
+	case kmac::flare::TlvType::AslrOffset:
+		if ( length == sizeof( std::uint64_t ) )
+		{
+			std::memcpy( &record.aslrOffset, value, sizeof( std::uint64_t ) );
+		}
+		break;
+
+	case kmac::flare::TlvType::RegisterLayout:
+		if ( length == sizeof( std::uint8_t ) )
+		{
+			std::memcpy( &record.registerLayout, value, sizeof( std::uint8_t ) );
+		}
+		break;
+
 	default:
 		break;
 	}
@@ -200,6 +228,27 @@ void TlvFieldParseHelper::parseStackFramesField( const std::uint8_t* value, std:
 		std::memcpy( &record.stackFrames.data()[ i ], value + i * sizeof( std::uint64_t ), sizeof( std::uint64_t ) );
 	}
 	record.stackFrameCount = copyCount;
+}
+
+void TlvFieldParseHelper::parseCpuRegistersField( const std::uint8_t* value, std::uint16_t length ) noexcept
+{
+	// payload is a packed array of uint64_t register values, little-endian;
+	// silently ignore malformed lengths (not a multiple of 8)
+	if ( length == 0 || ( length % sizeof( std::uint64_t ) ) != 0 )
+	{
+		return;
+	}
+
+	const std::size_t regCount = length / sizeof( std::uint64_t );
+	const std::size_t copyCount = regCount < kmac::flare::Record::MAX_REGISTERS
+		? regCount
+		: kmac::flare::Record::MAX_REGISTERS;
+
+	for ( std::size_t i = 0; i < copyCount; ++i )
+	{
+		std::memcpy( &record.registers.data()[ i ], value + i * sizeof( std::uint64_t ), sizeof( std::uint64_t ) );
+	}
+	record.registerCount = copyCount;
 }
 
 void TlvFieldParseHelper::parseStringField( kmac::flare::TlvType type, const std::uint8_t* value, std::uint16_t length ) noexcept

--- a/libs/nova_flare/src/kmac/flare/record.cpp
+++ b/libs/nova_flare/src/kmac/flare/record.cpp
@@ -23,6 +23,11 @@ void Record::clear() noexcept
 	messageLen = 0;
 	stackFrameCount = 0;
 	loadBaseAddress = 0;
+	faultAddress = 0;
+	aslrOffset = 0;
+	hasFaultAddress = false;
+	registerCount = 0;
+	registerLayout = 0;
 }
 
 const char* Record::statusString() const noexcept

--- a/libs/nova_flare/src/kmac/flare/signal_handler.cpp
+++ b/libs/nova_flare/src/kmac/flare/signal_handler.cpp
@@ -74,21 +74,21 @@ void SignalHandlerBase::install( char* altStackBuffer, std::size_t altStackSize,
 	altStack.ss_flags = 0;
 	sigaltstack( &altStack, nullptr );
 
-	struct sigaction sa {};
-	sa.sa_sigaction = signalHandler;
-	sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+	struct sigaction sigAct {};
+	sigAct.sa_sigaction = signalHandler;
+	sigAct.sa_flags = SA_SIGINFO | SA_ONSTACK;
 
 	// block all other handled signals during handler execution to prevent
 	// re-entrant delivery while writing the crash record
-	sigemptyset( &sa.sa_mask );
+	sigemptyset( &sigAct.sa_mask );
 	for ( std::size_t i = 0; i < NUM_SIGNALS; ++i )
 	{
-		sigaddset( &sa.sa_mask, HANDLED_SIGNALS[ i ] );
+		sigaddset( &sigAct.sa_mask, HANDLED_SIGNALS.at( i ) );
 	}
 
 	for ( std::size_t i = 0; i < NUM_SIGNALS; ++i )
 	{
-		sigaction( HANDLED_SIGNALS[ i ], &sa, &_previousActions[ i ] );
+		sigaction( HANDLED_SIGNALS.at( i ), &sigAct, &_previousActions.at( i ) );
 	}
 
 	_previousTerminateHandler = std::set_terminate( terminateHandler );
@@ -98,7 +98,7 @@ void SignalHandlerBase::uninstall() noexcept
 {
 	for ( std::size_t i = 0; i < NUM_SIGNALS; ++i )
 	{
-		sigaction( HANDLED_SIGNALS[ i ], &_previousActions[ i ], nullptr );
+		sigaction( HANDLED_SIGNALS.at( i ), &_previousActions.at( i ), nullptr );
 	}
 
 	if ( _previousTerminateHandler != nullptr )
@@ -136,8 +136,10 @@ void SignalHandlerBase::signalHandler( int signum, siginfo_t* info, void* uctx )
 		static constexpr std::size_t MSG_BUF = 32;
 		kmac::nova::platform::Array< char, MSG_BUF > msgBuf {};
 
-		// signal number to short name - covers the five signals we install for
-		const char* signame = "SIG?";
+		// signal number to short name - covers the five signals we install for;
+		// no default initialiser to avoid a dead-store warning: every reachable
+		// path through the switch sets signame before strncpy uses it
+		const char* signame;
 		switch ( signum )
 		{
 		case SIGSEGV: signame = "SIGSEGV"; break;
@@ -165,13 +167,13 @@ void SignalHandlerBase::signalHandler( int signum, siginfo_t* info, void* uctx )
 	// the correct signal status and a core dump is produced if configured
 	for ( std::size_t i = 0; i < NUM_SIGNALS; ++i )
 	{
-		if ( HANDLED_SIGNALS[ i ] == signum )
+		if ( HANDLED_SIGNALS.at( i ) == signum )
 		{
-			sigaction( signum, &_previousActions[ i ], nullptr );
+			sigaction( signum, &_previousActions.at( i ), nullptr );
 			break;
 		}
 	}
-	raise( signum );
+	(void) raise( signum ); // NOLINT(cert-err33-c) - no meaningful recovery if raise fails in a crash handler
 }
 
 void SignalHandlerBase::terminateHandler() noexcept
@@ -183,9 +185,9 @@ void SignalHandlerBase::terminateHandler() noexcept
 		ctx.aslrOffset = _sink->loadBaseAddress();
 
 		kmac::nova::Record record {};
-		static constexpr const char msg[] = "std::terminate";
+		static constexpr const char* msg = "std::terminate";
 		record.message = msg;
-		record.messageSize = sizeof( msg ) - 1;
+		record.messageSize = std::uint32_t( std::strlen( msg ) );
 		record.tag = "kmac::flare::SignalHandler";
 
 		_sink->processWithFaultContext( record, ctx );
@@ -243,46 +245,46 @@ void extractRegisters( const ucontext_t* uctx, kmac::flare::FaultContext& ctx ) 
 	}
 
 #if defined( __linux__ ) || defined( __ANDROID__ )
-	const mcontext_t& mc = uctx->uc_mcontext;
-	ctx.registers[ 0 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RAX ] );
-	ctx.registers[ 1 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RBX ] );
-	ctx.registers[ 2 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RCX ] );
-	ctx.registers[ 3 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RDX ] );
-	ctx.registers[ 4 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RSI ] );
-	ctx.registers[ 5 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RDI ] );
-	ctx.registers[ 6 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RBP ] );
-	ctx.registers[ 7 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RSP ] );
-	ctx.registers[ 8 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_R8  ] );
-	ctx.registers[ 9 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_R9  ] );
-	ctx.registers[ 10 ] = static_cast< std::uint64_t >( mc.gregs[ REG_R10 ] );
-	ctx.registers[ 11 ] = static_cast< std::uint64_t >( mc.gregs[ REG_R11 ] );
-	ctx.registers[ 12 ] = static_cast< std::uint64_t >( mc.gregs[ REG_R12 ] );
-	ctx.registers[ 13 ] = static_cast< std::uint64_t >( mc.gregs[ REG_R13 ] );
-	ctx.registers[ 14 ] = static_cast< std::uint64_t >( mc.gregs[ REG_R14 ] );
-	ctx.registers[ 15 ] = static_cast< std::uint64_t >( mc.gregs[ REG_R15 ] );
-	ctx.registers[ 16 ] = static_cast< std::uint64_t >( mc.gregs[ REG_RIP ] );
-	ctx.registers[ 17 ] = static_cast< std::uint64_t >( mc.gregs[ REG_EFL ] );
+	const mcontext_t& mctx = uctx->uc_mcontext;
+	ctx.registers[ 0 ]  = static_cast< std::uint64_t >( mctx.gregs[ REG_RAX ] );
+	ctx.registers[ 1 ]  = static_cast< std::uint64_t >( mctx.gregs[ REG_RBX ] );
+	ctx.registers[ 2 ]  = static_cast< std::uint64_t >( mctx.gregs[ REG_RCX ] );
+	ctx.registers[ 3 ]  = static_cast< std::uint64_t >( mctx.gregs[ REG_RDX ] );
+	ctx.registers[ 4 ]  = static_cast< std::uint64_t >( mctx.gregs[ REG_RSI ] );
+	ctx.registers[ 5 ]  = static_cast< std::uint64_t >( mctx.gregs[ REG_RDI ] );
+	ctx.registers[ 6 ]  = static_cast< std::uint64_t >( mctx.gregs[ REG_RBP ] );
+	ctx.registers[ 7 ]  = static_cast< std::uint64_t >( mctx.gregs[ REG_RSP ] );
+	ctx.registers[ 8 ]  = static_cast< std::uint64_t >( mctx.gregs[ REG_R8  ] );
+	ctx.registers[ 9 ]  = static_cast< std::uint64_t >( mctx.gregs[ REG_R9  ] );
+	ctx.registers[ 10 ] = static_cast< std::uint64_t >( mctx.gregs[ REG_R10 ] );
+	ctx.registers[ 11 ] = static_cast< std::uint64_t >( mctx.gregs[ REG_R11 ] );
+	ctx.registers[ 12 ] = static_cast< std::uint64_t >( mctx.gregs[ REG_R12 ] );
+	ctx.registers[ 13 ] = static_cast< std::uint64_t >( mctx.gregs[ REG_R13 ] );
+	ctx.registers[ 14 ] = static_cast< std::uint64_t >( mctx.gregs[ REG_R14 ] );
+	ctx.registers[ 15 ] = static_cast< std::uint64_t >( mctx.gregs[ REG_R15 ] );
+	ctx.registers[ 16 ] = static_cast< std::uint64_t >( mctx.gregs[ REG_RIP ] );
+	ctx.registers[ 17 ] = static_cast< std::uint64_t >( mctx.gregs[ REG_EFL ] );
 	ctx.registerCount   = 18;
 #elif defined( __APPLE__ )
-	const mcontext_t mc = uctx->uc_mcontext;
-	ctx.registers[ 0 ]  = mc->__ss.__rax;
-	ctx.registers[ 1 ]  = mc->__ss.__rbx;
-	ctx.registers[ 2 ]  = mc->__ss.__rcx;
-	ctx.registers[ 3 ]  = mc->__ss.__rdx;
-	ctx.registers[ 4 ]  = mc->__ss.__rsi;
-	ctx.registers[ 5 ]  = mc->__ss.__rdi;
-	ctx.registers[ 6 ]  = mc->__ss.__rbp;
-	ctx.registers[ 7 ]  = mc->__ss.__rsp;
-	ctx.registers[ 8 ]  = mc->__ss.__r8;
-	ctx.registers[ 9 ]  = mc->__ss.__r9;
-	ctx.registers[ 10 ] = mc->__ss.__r10;
-	ctx.registers[ 11 ] = mc->__ss.__r11;
-	ctx.registers[ 12 ] = mc->__ss.__r12;
-	ctx.registers[ 13 ] = mc->__ss.__r13;
-	ctx.registers[ 14 ] = mc->__ss.__r14;
-	ctx.registers[ 15 ] = mc->__ss.__r15;
-	ctx.registers[ 16 ] = mc->__ss.__rip;
-	ctx.registers[ 17 ] = mc->__ss.__rflags;
+	const mcontext_t mctx = uctx->uc_mcontext;
+	ctx.registers[ 0 ]  = mctx->__ss.__rax;
+	ctx.registers[ 1 ]  = mctx->__ss.__rbx;
+	ctx.registers[ 2 ]  = mctx->__ss.__rcx;
+	ctx.registers[ 3 ]  = mctx->__ss.__rdx;
+	ctx.registers[ 4 ]  = mctx->__ss.__rsi;
+	ctx.registers[ 5 ]  = mctx->__ss.__rdi;
+	ctx.registers[ 6 ]  = mctx->__ss.__rbp;
+	ctx.registers[ 7 ]  = mctx->__ss.__rsp;
+	ctx.registers[ 8 ]  = mctx->__ss.__r8;
+	ctx.registers[ 9 ]  = mctx->__ss.__r9;
+	ctx.registers[ 10 ] = mctx->__ss.__r10;
+	ctx.registers[ 11 ] = mctx->__ss.__r11;
+	ctx.registers[ 12 ] = mctx->__ss.__r12;
+	ctx.registers[ 13 ] = mctx->__ss.__r13;
+	ctx.registers[ 14 ] = mctx->__ss.__r14;
+	ctx.registers[ 15 ] = mctx->__ss.__r15;
+	ctx.registers[ 16 ] = mctx->__ss.__rip;
+	ctx.registers[ 17 ] = mctx->__ss.__rflags;
 	ctx.registerCount   = 18;
 #endif
 
@@ -299,27 +301,27 @@ void extractRegisters( const ucontext_t* uctx, kmac::flare::FaultContext& ctx ) 
 	}
 
 #if defined( __linux__ ) || defined( __ANDROID__ )
-	const mcontext_t& mc = uctx->uc_mcontext;
+	const mcontext_t& mctx = uctx->uc_mcontext;
 	// x0-x30 (31 general-purpose registers)
 	for ( std::size_t i = 0; i < 31; ++i )
 	{
-		ctx.registers[ i ] = mc.regs[ i ];
+		ctx.registers[ i ] = mctx.regs[ i ];
 	}
-	ctx.registers[ 31 ] = mc.sp;
-	ctx.registers[ 32 ] = mc.pc;
-	ctx.registers[ 33 ] = static_cast< std::uint64_t >( mc.pstate );
+	ctx.registers[ 31 ] = mctx.sp;
+	ctx.registers[ 32 ] = mctx.pc;
+	ctx.registers[ 33 ] = static_cast< std::uint64_t >( mctx.pstate );
 	ctx.registerCount   = 34;
 #elif defined( __APPLE__ )
-	const mcontext_t mc = uctx->uc_mcontext;
+	const mcontext_t mctx = uctx->uc_mcontext;
 	for ( std::size_t i = 0; i < 29; ++i )
 	{
-		ctx.registers[ i ] = mc->__ss.__x[ i ];
+		ctx.registers[ i ] = mctx->__ss.__x[ i ];
 	}
-	ctx.registers[ 29 ] = mc->__ss.__fp;
-	ctx.registers[ 30 ] = mc->__ss.__lr;
-	ctx.registers[ 31 ] = mc->__ss.__sp;
-	ctx.registers[ 32 ] = mc->__ss.__pc;
-	ctx.registers[ 33 ] = mc->__ss.__cpsr;
+	ctx.registers[ 29 ] = mctx->__ss.__fp;
+	ctx.registers[ 30 ] = mctx->__ss.__lr;
+	ctx.registers[ 31 ] = mctx->__ss.__sp;
+	ctx.registers[ 32 ] = mctx->__ss.__pc;
+	ctx.registers[ 33 ] = mctx->__ss.__cpsr;
 	ctx.registerCount   = 34;
 #endif
 
@@ -336,25 +338,25 @@ void extractRegisters( const ucontext_t* uctx, kmac::flare::FaultContext& ctx ) 
 	}
 
 #if defined( __linux__ ) || defined( __ANDROID__ )
-	const mcontext_t& mc = uctx->uc_mcontext;
+	const mcontext_t& mctx = uctx->uc_mcontext;
 	// r0-r10 (arm_r0..arm_r10), fp=r11, ip=r12, sp=r13, lr=r14, pc=r15, cpsr
-	ctx.registers[ 0 ]  = mc.arm_r0;
-	ctx.registers[ 1 ]  = mc.arm_r1;
-	ctx.registers[ 2 ]  = mc.arm_r2;
-	ctx.registers[ 3 ]  = mc.arm_r3;
-	ctx.registers[ 4 ]  = mc.arm_r4;
-	ctx.registers[ 5 ]  = mc.arm_r5;
-	ctx.registers[ 6 ]  = mc.arm_r6;
-	ctx.registers[ 7 ]  = mc.arm_r7;
-	ctx.registers[ 8 ]  = mc.arm_r8;
-	ctx.registers[ 9 ]  = mc.arm_r9;
-	ctx.registers[ 10 ] = mc.arm_r10;
-	ctx.registers[ 11 ] = mc.arm_fp;   // r11
-	ctx.registers[ 12 ] = mc.arm_ip;   // r12
-	ctx.registers[ 13 ] = mc.arm_sp;   // r13
-	ctx.registers[ 14 ] = mc.arm_lr;   // r14
-	ctx.registers[ 15 ] = mc.arm_pc;   // r15
-	ctx.registers[ 16 ] = mc.arm_cpsr;
+	ctx.registers[ 0 ]  = mctx.arm_r0;
+	ctx.registers[ 1 ]  = mctx.arm_r1;
+	ctx.registers[ 2 ]  = mctx.arm_r2;
+	ctx.registers[ 3 ]  = mctx.arm_r3;
+	ctx.registers[ 4 ]  = mctx.arm_r4;
+	ctx.registers[ 5 ]  = mctx.arm_r5;
+	ctx.registers[ 6 ]  = mctx.arm_r6;
+	ctx.registers[ 7 ]  = mctx.arm_r7;
+	ctx.registers[ 8 ]  = mctx.arm_r8;
+	ctx.registers[ 9 ]  = mctx.arm_r9;
+	ctx.registers[ 10 ] = mctx.arm_r10;
+	ctx.registers[ 11 ] = mctx.arm_fp;   // r11
+	ctx.registers[ 12 ] = mctx.arm_ip;   // r12
+	ctx.registers[ 13 ] = mctx.arm_sp;   // r13
+	ctx.registers[ 14 ] = mctx.arm_lr;   // r14
+	ctx.registers[ 15 ] = mctx.arm_pc;   // r15
+	ctx.registers[ 16 ] = mctx.arm_cpsr;
 	ctx.registerCount   = 17;
 #endif
 

--- a/libs/nova_flare/src/kmac/flare/signal_handler.cpp
+++ b/libs/nova_flare/src/kmac/flare/signal_handler.cpp
@@ -42,7 +42,7 @@ namespace kmac::flare
 // static member definitions
 // ============================================================================
 
-const kmac::nova::platform::Array< int, NUM_SIGNALS > SignalHandlerBase::HANDLED_SIGNALS = {
+const kmac::nova::platform::Array< int, SignalHandlerBase::NUM_SIGNALS > SignalHandlerBase::HANDLED_SIGNALS = {
 	SIGSEGV,
 	SIGBUS,
 	SIGFPE,
@@ -53,7 +53,7 @@ const kmac::nova::platform::Array< int, NUM_SIGNALS > SignalHandlerBase::HANDLED
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 EmergencySinkBase* SignalHandlerBase::_sink = nullptr;
 
-kmac::nova::platform::Array< struct sigaction, NUM_SIGNALS > SignalHandlerBase::_previousActions {};
+kmac::nova::platform::Array< sigaction, SignalHandlerBase::NUM_SIGNALS > SignalHandlerBase::_previousActions {};
 
 void ( *SignalHandlerBase::_previousTerminateHandler )() = nullptr;
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)

--- a/libs/nova_flare/src/kmac/flare/signal_handler.cpp
+++ b/libs/nova_flare/src/kmac/flare/signal_handler.cpp
@@ -1,0 +1,375 @@
+#include "kmac/flare/signal_handler.h"
+
+#if defined( FLARE_HAVE_FAULT_CONTEXT )
+
+#include "kmac/flare/tlv.h"
+
+#include <kmac/nova/record.h>
+#include <kmac/nova/platform/array.h>
+
+#include <cstring>
+#include <exception>    // std::set_terminate
+#include <signal.h>
+#include <stdint.h>
+#include <ucontext.h>
+
+namespace
+{
+
+/**
+ * @brief Architecture-specific register extraction from ucontext_t.
+ *
+ * Each platform exposes the saved register state differently.  We extract
+ * only what ucontext_t gives us directly - no extra unwinding required.
+ *
+ * Layout IDs must match RegisterLayoutId in tlv.h:
+ *   X86_64 = 1 : rax, rbx, rcx, rdx, rsi, rdi, rbp, rsp, r8-r15, rip, rflags
+ *   Arm64  = 2 : x0-x30, sp, pc, pstate
+ *   Arm32  = 3 : r0-r15, cpsr
+ *
+ * @param uctx ucontext_t captured by the signal handler (may be nullptr on
+ *        unsupported platforms, in which case no registers are extracted)
+ * @param ctx output FaultContext to populate with register values and layout ID
+ */
+void extractRegisters( const ucontext_t* uctx, kmac::flare::FaultContext& ctx ) noexcept;
+
+} // anonymous namespace
+
+namespace kmac::flare
+{
+
+// ============================================================================
+// static member definitions
+// ============================================================================
+
+const kmac::nova::platform::Array< int, NUM_SIGNALS > SignalHandlerBase::HANDLED_SIGNALS = {
+	SIGSEGV,
+	SIGBUS,
+	SIGFPE,
+	SIGILL,
+	SIGABRT,
+};
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+EmergencySinkBase* SignalHandlerBase::_sink = nullptr;
+
+kmac::nova::platform::Array< struct sigaction, NUM_SIGNALS > SignalHandlerBase::_previousActions {};
+
+void ( *SignalHandlerBase::_previousTerminateHandler )() = nullptr;
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+// ============================================================================
+// install / uninstall
+// ============================================================================
+
+void SignalHandlerBase::install( char* altStackBuffer, std::size_t altStackSize, EmergencySinkBase* sink ) noexcept
+{
+	_sink = sink;
+
+	// configure alternate signal stack so we can handle stack-overflow SIGSEGV;
+	// the faulting stack cannot be used to execute the handler
+	stack_t altStack {};
+	altStack.ss_sp = altStackBuffer;
+	altStack.ss_size = altStackSize;
+	altStack.ss_flags = 0;
+	sigaltstack( &altStack, nullptr );
+
+	struct sigaction sa {};
+	sa.sa_sigaction = signalHandler;
+	sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+
+	// block all other handled signals during handler execution to prevent
+	// re-entrant delivery while writing the crash record
+	sigemptyset( &sa.sa_mask );
+	for ( std::size_t i = 0; i < NUM_SIGNALS; ++i )
+	{
+		sigaddset( &sa.sa_mask, HANDLED_SIGNALS[ i ] );
+	}
+
+	for ( std::size_t i = 0; i < NUM_SIGNALS; ++i )
+	{
+		sigaction( HANDLED_SIGNALS[ i ], &sa, &_previousActions[ i ] );
+	}
+
+	_previousTerminateHandler = std::set_terminate( terminateHandler );
+}
+
+void SignalHandlerBase::uninstall() noexcept
+{
+	for ( std::size_t i = 0; i < NUM_SIGNALS; ++i )
+	{
+		sigaction( HANDLED_SIGNALS[ i ], &_previousActions[ i ], nullptr );
+	}
+
+	if ( _previousTerminateHandler != nullptr )
+	{
+		std::set_terminate( _previousTerminateHandler );
+		_previousTerminateHandler = nullptr;
+	}
+
+	// disable the alternate stack
+	stack_t disabledStack {};
+	disabledStack.ss_flags = SS_DISABLE;
+	sigaltstack( &disabledStack, nullptr );
+
+	_sink = nullptr;
+}
+
+// ============================================================================
+// private implementation
+// ============================================================================
+
+void SignalHandlerBase::signalHandler( int signum, siginfo_t* info, void* uctx ) noexcept
+{
+	if ( _sink != nullptr )
+	{
+		FaultContext ctx {};
+		buildFaultContext( info, uctx, ctx );
+
+		// build a minimal Nova record carrying the signal number as the message;
+		// source location is not meaningful here (we are inside the signal handler)
+		// so we leave file/function/line at their zero-initialised defaults
+		kmac::nova::Record record {};
+
+		// write the signal name into a small stack buffer for the message field
+		// async-signal-safe (no heap, no stdio)
+		static constexpr std::size_t MSG_BUF = 32;
+		kmac::nova::platform::Array< char, MSG_BUF > msgBuf {};
+
+		// signal number to short name - covers the five signals we install for
+		const char* signame = "SIG?";
+		switch ( signum )
+		{
+		case SIGSEGV: signame = "SIGSEGV"; break;
+		case SIGBUS:  signame = "SIGBUS";  break;
+		case SIGFPE:  signame = "SIGFPE";  break;
+		case SIGILL:  signame = "SIGILL";  break;
+		case SIGABRT: signame = "SIGABRT"; break;
+		default:      signame = "SIG?";   break;
+		}
+
+		// copy the character array into the buffer
+		std::strncpy( msgBuf.data(), signame, MSG_BUF - 1 );
+
+		// force the last character in the buffer to be the string terminator
+		msgBuf[ MSG_BUF - 1 ] = '\0';
+
+		record.message = msgBuf.data();
+		record.messageSize = std::uint32_t( std::strlen( msgBuf.data() ) );
+		record.tag = "kmac::flare::SignalHandler";
+
+		_sink->processWithFaultContext( record, ctx );
+	}
+
+	// restore the previous disposition and re-raise so the process exits with
+	// the correct signal status and a core dump is produced if configured
+	for ( std::size_t i = 0; i < NUM_SIGNALS; ++i )
+	{
+		if ( HANDLED_SIGNALS[ i ] == signum )
+		{
+			sigaction( signum, &_previousActions[ i ], nullptr );
+			break;
+		}
+	}
+	raise( signum );
+}
+
+void SignalHandlerBase::terminateHandler() noexcept
+{
+	if ( _sink != nullptr )
+	{
+		FaultContext ctx {};
+		// no siginfo_t available from terminate; aslrOffset is still useful
+		ctx.aslrOffset = _sink->loadBaseAddress();
+
+		kmac::nova::Record record {};
+		static constexpr const char msg[] = "std::terminate";
+		record.message = msg;
+		record.messageSize = sizeof( msg ) - 1;
+		record.tag = "kmac::flare::SignalHandler";
+
+		_sink->processWithFaultContext( record, ctx );
+	}
+
+	// chain to the previous terminate handler if there was one, otherwise abort
+	if ( _previousTerminateHandler != nullptr )
+	{
+		_previousTerminateHandler();
+	}
+	else
+	{
+		__builtin_trap();
+	}
+}
+
+void SignalHandlerBase::buildFaultContext( const siginfo_t* info, const void* uctx, FaultContext& ctx ) noexcept
+{
+	// fault address from siginfo_t - meaningful for SIGSEGV, SIGBUS, SIGFPE, SIGILL;
+	// SIGABRT sets si_addr to 0 or the address of the abort() call, so we only
+	// record hasFaultAddress=true when si_addr is non-null
+	if ( info != nullptr )
+	{
+		// NOLINT NOTE: reinterpret_cast required to convert void* si_addr to uint64_t
+		ctx.faultAddress = reinterpret_cast< std::uint64_t >( info->si_addr ); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+		ctx.hasFaultAddress = ( info->si_addr != nullptr );
+	}
+
+	// ASLR offset: stored in the sink at construction time; copy it here so the
+	// TLV record is self-contained without requiring the reader to have the binary
+	if ( _sink != nullptr )
+	{
+		ctx.aslrOffset = _sink->loadBaseAddress();
+	}
+
+	// CPU registers from ucontext_t
+	const auto* ucontextTyped = static_cast< const ucontext_t* >( uctx );
+	extractRegisters( ucontextTyped, ctx );
+}
+
+} // namespace kmac::flare
+
+namespace
+{
+
+// define extractRegisters for each platform
+
+#if defined( __x86_64__ )
+
+void extractRegisters( const ucontext_t* uctx, kmac::flare::FaultContext& ctx ) noexcept
+{
+	if ( uctx == nullptr )
+	{
+		return;
+	}
+
+#if defined( __linux__ ) || defined( __ANDROID__ )
+	const mcontext_t& mc = uctx->uc_mcontext;
+	ctx.registers[ 0 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RAX ] );
+	ctx.registers[ 1 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RBX ] );
+	ctx.registers[ 2 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RCX ] );
+	ctx.registers[ 3 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RDX ] );
+	ctx.registers[ 4 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RSI ] );
+	ctx.registers[ 5 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RDI ] );
+	ctx.registers[ 6 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RBP ] );
+	ctx.registers[ 7 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_RSP ] );
+	ctx.registers[ 8 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_R8  ] );
+	ctx.registers[ 9 ]  = static_cast< std::uint64_t >( mc.gregs[ REG_R9  ] );
+	ctx.registers[ 10 ] = static_cast< std::uint64_t >( mc.gregs[ REG_R10 ] );
+	ctx.registers[ 11 ] = static_cast< std::uint64_t >( mc.gregs[ REG_R11 ] );
+	ctx.registers[ 12 ] = static_cast< std::uint64_t >( mc.gregs[ REG_R12 ] );
+	ctx.registers[ 13 ] = static_cast< std::uint64_t >( mc.gregs[ REG_R13 ] );
+	ctx.registers[ 14 ] = static_cast< std::uint64_t >( mc.gregs[ REG_R14 ] );
+	ctx.registers[ 15 ] = static_cast< std::uint64_t >( mc.gregs[ REG_R15 ] );
+	ctx.registers[ 16 ] = static_cast< std::uint64_t >( mc.gregs[ REG_RIP ] );
+	ctx.registers[ 17 ] = static_cast< std::uint64_t >( mc.gregs[ REG_EFL ] );
+	ctx.registerCount   = 18;
+#elif defined( __APPLE__ )
+	const mcontext_t mc = uctx->uc_mcontext;
+	ctx.registers[ 0 ]  = mc->__ss.__rax;
+	ctx.registers[ 1 ]  = mc->__ss.__rbx;
+	ctx.registers[ 2 ]  = mc->__ss.__rcx;
+	ctx.registers[ 3 ]  = mc->__ss.__rdx;
+	ctx.registers[ 4 ]  = mc->__ss.__rsi;
+	ctx.registers[ 5 ]  = mc->__ss.__rdi;
+	ctx.registers[ 6 ]  = mc->__ss.__rbp;
+	ctx.registers[ 7 ]  = mc->__ss.__rsp;
+	ctx.registers[ 8 ]  = mc->__ss.__r8;
+	ctx.registers[ 9 ]  = mc->__ss.__r9;
+	ctx.registers[ 10 ] = mc->__ss.__r10;
+	ctx.registers[ 11 ] = mc->__ss.__r11;
+	ctx.registers[ 12 ] = mc->__ss.__r12;
+	ctx.registers[ 13 ] = mc->__ss.__r13;
+	ctx.registers[ 14 ] = mc->__ss.__r14;
+	ctx.registers[ 15 ] = mc->__ss.__r15;
+	ctx.registers[ 16 ] = mc->__ss.__rip;
+	ctx.registers[ 17 ] = mc->__ss.__rflags;
+	ctx.registerCount   = 18;
+#endif
+
+	ctx.layoutId = std::uint8_t( kmac::flare::RegisterLayoutId::X86_64 );
+}
+
+#elif defined( __aarch64__ )
+
+void extractRegisters( const ucontext_t* uctx, kmac::flare::FaultContext& ctx ) noexcept
+{
+	if ( uctx == nullptr )
+	{
+		return;
+	}
+
+#if defined( __linux__ ) || defined( __ANDROID__ )
+	const mcontext_t& mc = uctx->uc_mcontext;
+	// x0-x30 (31 general-purpose registers)
+	for ( std::size_t i = 0; i < 31; ++i )
+	{
+		ctx.registers[ i ] = mc.regs[ i ];
+	}
+	ctx.registers[ 31 ] = mc.sp;
+	ctx.registers[ 32 ] = mc.pc;
+	ctx.registers[ 33 ] = static_cast< std::uint64_t >( mc.pstate );
+	ctx.registerCount   = 34;
+#elif defined( __APPLE__ )
+	const mcontext_t mc = uctx->uc_mcontext;
+	for ( std::size_t i = 0; i < 29; ++i )
+	{
+		ctx.registers[ i ] = mc->__ss.__x[ i ];
+	}
+	ctx.registers[ 29 ] = mc->__ss.__fp;
+	ctx.registers[ 30 ] = mc->__ss.__lr;
+	ctx.registers[ 31 ] = mc->__ss.__sp;
+	ctx.registers[ 32 ] = mc->__ss.__pc;
+	ctx.registers[ 33 ] = mc->__ss.__cpsr;
+	ctx.registerCount   = 34;
+#endif
+
+	ctx.layoutId = std::uint8_t( kmac::flare::RegisterLayoutId::Arm64 );
+}
+
+#elif defined( __arm__ )
+
+void extractRegisters( const ucontext_t* uctx, kmac::flare::FaultContext& ctx ) noexcept
+{
+	if ( uctx == nullptr )
+	{
+		return;
+	}
+
+#if defined( __linux__ ) || defined( __ANDROID__ )
+	const mcontext_t& mc = uctx->uc_mcontext;
+	// r0-r10 (arm_r0..arm_r10), fp=r11, ip=r12, sp=r13, lr=r14, pc=r15, cpsr
+	ctx.registers[ 0 ]  = mc.arm_r0;
+	ctx.registers[ 1 ]  = mc.arm_r1;
+	ctx.registers[ 2 ]  = mc.arm_r2;
+	ctx.registers[ 3 ]  = mc.arm_r3;
+	ctx.registers[ 4 ]  = mc.arm_r4;
+	ctx.registers[ 5 ]  = mc.arm_r5;
+	ctx.registers[ 6 ]  = mc.arm_r6;
+	ctx.registers[ 7 ]  = mc.arm_r7;
+	ctx.registers[ 8 ]  = mc.arm_r8;
+	ctx.registers[ 9 ]  = mc.arm_r9;
+	ctx.registers[ 10 ] = mc.arm_r10;
+	ctx.registers[ 11 ] = mc.arm_fp;   // r11
+	ctx.registers[ 12 ] = mc.arm_ip;   // r12
+	ctx.registers[ 13 ] = mc.arm_sp;   // r13
+	ctx.registers[ 14 ] = mc.arm_lr;   // r14
+	ctx.registers[ 15 ] = mc.arm_pc;   // r15
+	ctx.registers[ 16 ] = mc.arm_cpsr;
+	ctx.registerCount   = 17;
+#endif
+
+	ctx.layoutId = std::uint8_t( kmac::flare::RegisterLayoutId::Arm32 );
+}
+
+#else
+
+// Unsupported architecture - no register capture
+void extractRegisters( const ucontext_t* /*uctx*/, kmac::flare::FaultContext& /*ctx*/ ) noexcept
+{
+}
+
+#endif  // architecture dispatch
+
+} // anonymous namespace
+
+#endif // FLARE_HAVE_FAULT_CONTEXT (i.e. POSIX platforms)

--- a/libs/nova_flare/src/kmac/flare/signal_handler.cpp
+++ b/libs/nova_flare/src/kmac/flare/signal_handler.cpp
@@ -53,7 +53,7 @@ const kmac::nova::platform::Array< int, SignalHandlerBase::NUM_SIGNALS > SignalH
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 EmergencySinkBase* SignalHandlerBase::_sink = nullptr;
 
-kmac::nova::platform::Array< sigaction, SignalHandlerBase::NUM_SIGNALS > SignalHandlerBase::_previousActions {};
+kmac::nova::platform::Array< struct sigaction, SignalHandlerBase::NUM_SIGNALS > SignalHandlerBase::_previousActions {};
 
 void ( *SignalHandlerBase::_previousTerminateHandler )() = nullptr;
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)

--- a/libs/nova_flare/src/kmac/flare/signal_handler.cpp
+++ b/libs/nova_flare/src/kmac/flare/signal_handler.cpp
@@ -139,7 +139,7 @@ void SignalHandlerBase::signalHandler( int signum, siginfo_t* info, void* uctx )
 		// signal number to short name - covers the five signals we install for;
 		// no default initialiser to avoid a dead-store warning: every reachable
 		// path through the switch sets signame before strncpy uses it
-		const char* signame;
+		const char* signame = nullptr;
 		switch ( signum )
 		{
 		case SIGSEGV: signame = "SIGSEGV"; break;


### PR DESCRIPTION
#66: Added a new SignalHandler class to Flare to simplify installing signal handlers, and expanded the values written, including: fault address, ASLR offset, and register info.